### PR TITLE
[FIX] endpoint 수정 : API 문서 컨벤션 양식에 맞춰 수정

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/qna/controller/QnaController.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/controller/QnaController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/qna")
+@RequestMapping("kbuddy/v1/qna")
 public class QnaController {
 
     private final QnaService qnaService;

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/user/auth")
+@RequestMapping("/kbuddy/v1/user/auth")
 public class UserAuthController {
 
     private final UserAuthService userAuthService;

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserPageController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserPageController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/user")
+@RequestMapping("/kbuddy/v1/user")
 public class UserPageController {
 
 	private final UserService userService;

--- a/src/test/java/com/example/kbuddy_backend/auth/config/JwtFilterTest.java
+++ b/src/test/java/com/example/kbuddy_backend/auth/config/JwtFilterTest.java
@@ -34,7 +34,7 @@ class JwtFilterTest extends WebMVCTest {
         given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
 
         //then
-        mockMvc.perform(get("/api/v1/user/auth/authentication")
+        mockMvc.perform(get("/kbuddy/v1/user/auth/authentication")
                         .header("Authorization", "Bearer validToken"))
                 .andExpect(status().isOk());
     }
@@ -48,7 +48,7 @@ class JwtFilterTest extends WebMVCTest {
         //when
 
         //then
-        mockMvc.perform(get("/api/v1/user/auth/authentication")
+        mockMvc.perform(get("/kbuddy/v1/user/auth/authentication")
                         .header("Authorization", "Bearer invalidToken"))
                 .andExpect(status().isUnauthorized());
     }
@@ -58,7 +58,7 @@ class JwtFilterTest extends WebMVCTest {
     void checkNullToken() throws Exception {
 
         //then
-        mockMvc.perform(get("/api/v1/user/auth/authentication"))
+        mockMvc.perform(get("/kbuddy/v1/user/auth/authentication"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/example/kbuddy_backend/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/com/example/kbuddy_backend/user/controller/UserAuthControllerTest.java
@@ -26,7 +26,7 @@ class UserAuthControllerTest extends WebMVCTest {
         //when
         
         //then
-        mockMvc.perform(post("/api/v1/user/auth/login").content(objectMapper.writeValueAsString(registerRequest))
+        mockMvc.perform(post("/kbuddy/v1/user/auth/login").content(objectMapper.writeValueAsString(registerRequest))
                 .contentType(APPLICATION_JSON)).andDo(print())
                 .andExpect(status().isOk());
      }


### PR DESCRIPTION
## Description (요약)
API Endpoint URL 수정 (/api/v1/~~~를 /kbuddy/v1/~~~ 로)
- 기존 : https://api.bnbong.xyz/api/v1/~~~
- 수정 : https://api.bnbong.xyz/kbuddy/v1/~~~

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [ ] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [X] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
localhost

## Major Changes (주요 변경사항)
API 문서 명세에 맞게 /api 로 시작하던 url을 /kbuddy로 변경하였습니다.

이는 도메인 구분 상 하위 도메인으로 이미 `api.`로 api endpoint임을 명시(**api**.bnbong.xyz)하고 있기에 url로 api를 중복 명시하는 것을 막기 위함이며

향후 추가할 수도 있는 Gateway 패턴을 적용하기 용이하게 하기 위함입니다.

## Screenshots (optional)
None

## Etc (비고)

Mock 서비스는 하위 도메인으로 `mock.` 을 사용하여 **mock.bnbong.xyz** 로 요청을 보내도록 구성할 계획입니다.