### PR TITLE
[FIX] 구글 계정 credential 그대로 노출되는 코드 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           platforms: arm64
 
+      - name: Set environment variables
+        run: |
+          echo "EMAIL_USERNAME=${{ secrets.EMAIL_USERNAME }}" >> $GITHUB_ENV
+          echo "EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,6 +17,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Set environment variables
+        run: |
+          echo "EMAIL_USERNAME=${{ secrets.EMAIL_USERNAME }}" >> $GITHUB_ENV
+          echo "EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }}" >> $GITHUB_ENV
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/src/main/java/com/example/kbuddy_backend/auth/service/MailSendService.java
+++ b/src/main/java/com/example/kbuddy_backend/auth/service/MailSendService.java
@@ -1,11 +1,15 @@
 package com.example.kbuddy_backend.auth.service;
 
 import com.example.kbuddy_backend.common.util.RedisUtil;
+
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+
 import java.util.Random;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -15,61 +19,61 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MailSendService {
 
-    private final JavaMailSender mailSender;
-    private final RedisUtil redisUtil;
-    private int authNumber;
+	private final JavaMailSender mailSender;
+	private final RedisUtil redisUtil;
+	private int authNumber;
 
-    //임의의 6자리 양수를 반환
-    public void makeRandomNumber() {
-        Random r = new Random();
-        StringBuilder randomNumber = new StringBuilder();
-        for (int i = 0; i < 6; i++) {
-            randomNumber.append(Integer.toString(r.nextInt(10)));
-        }
+	//임의의 6자리 양수를 반환
+	public void makeRandomNumber() {
+		Random r = new Random();
+		StringBuilder randomNumber = new StringBuilder();
+		for (int i = 0; i < 6; i++) {
+			randomNumber.append(Integer.toString(r.nextInt(10)));
+		}
 
-        authNumber = Integer.parseInt(randomNumber.toString());
-    }
+		authNumber = Integer.parseInt(randomNumber.toString());
+	}
 
-    public boolean CheckAuthNum(String email, String authNum) {
-        if (redisUtil.getData(authNum) == null) {
-            return false;
-        } else
-            return redisUtil.getData(authNum).equals(email);
-    }
+	public boolean CheckAuthNum(String email, String authNum) {
+		if (redisUtil.getData(authNum) == null) {
+			return false;
+		} else
+			return redisUtil.getData(authNum).equals(email);
+	}
 
-    //mail을 어디서 보내는지, 어디로 보내는지 , 인증 번호를 html 형식으로 어떻게 보내는지 작성.
-    public String joinEmail(String email) {
-        makeRandomNumber();
-        String setFrom = "tripcompany77@gmail.com";
-        String title = "AUTH CODE for K-Buddy Registration"; // 이메일 제목
-        String content =
-                "Welcome to K-Buddy" +    //html 형식으로 작성 !
-                        "<br><br>" +
-                        "Auth number is " + authNumber + "." +
-                        "<br>" +
-                        "Please write a correct auth code."; //이메일 내용 삽입
-        mailSend(setFrom, email, title, content);
-        return Integer.toString(authNumber);
-    }
+	//mail을 어디서 보내는지, 어디로 보내는지 , 인증 번호를 html 형식으로 어떻게 보내는지 작성.
+	public String joinEmail(String email) {
+		makeRandomNumber();
+		String setFrom = "officialkbuddy@gmail.com";
+		String title = "AUTH CODE for K-Buddy Registration"; // 이메일 제목
+		String content =
+			"Welcome to K-Buddy" +    //html 형식으로 작성 !
+				"<br><br>" +
+				"Auth number is " + authNumber + "." +
+				"<br>" +
+				"Please write a correct auth code."; //이메일 내용 삽입
+		mailSend(setFrom, email, title, content);
+		return Integer.toString(authNumber);
+	}
 
-    //이메일을 전송합니다.
-    public void mailSend(String setFrom, String toMail, String title, String content) {
-        MimeMessage message = mailSender.createMimeMessage();//JavaMailSender 객체를 사용하여 MimeMessage 객체를 생성
-        try {
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "utf-8");//이메일 메시지와 관련된 설정을 수행합니다.
-            // true를 전달하여 multipart 형식의 메시지를 지원하고, "utf-8"을 전달하여 문자 인코딩을 설정
-            helper.setFrom(setFrom);//이메일의 발신자 주소 설정
-            helper.setTo(toMail);//이메일의 수신자 주소 설정
-            helper.setSubject(title);//이메일의 제목을 설정
-            helper.setText(content, true);//이메일의 내용 설정 두 번째 매개 변수에 true를 설정하여 html 설정으로한다.
-            mailSender.send(message);
-        } catch (MessagingException e) {//이메일 서버에 연결할 수 없거나, 잘못된 이메일 주소를 사용하거나, 인증 오류가 발생하는 등 오류
+	//이메일을 전송합니다.
+	public void mailSend(String setFrom, String toMail, String title, String content) {
+		MimeMessage message = mailSender.createMimeMessage();//JavaMailSender 객체를 사용하여 MimeMessage 객체를 생성
+		try {
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "utf-8");//이메일 메시지와 관련된 설정을 수행합니다.
+			// true를 전달하여 multipart 형식의 메시지를 지원하고, "utf-8"을 전달하여 문자 인코딩을 설정
+			helper.setFrom(setFrom);//이메일의 발신자 주소 설정
+			helper.setTo(toMail);//이메일의 수신자 주소 설정
+			helper.setSubject(title);//이메일의 제목을 설정
+			helper.setText(content, true);//이메일의 내용 설정 두 번째 매개 변수에 true를 설정하여 html 설정으로한다.
+			mailSender.send(message);
+		} catch (MessagingException e) {//이메일 서버에 연결할 수 없거나, 잘못된 이메일 주소를 사용하거나, 인증 오류가 발생하는 등 오류
 
-            log.error("이메일 전송 에러 발생", e);
-        }
-        //인증 코드는 5분간 유효
-        redisUtil.setDataExpire(Integer.toString(authNumber), toMail, 60 * 5L);
+			log.error("이메일 전송 에러 발생", e);
+		}
+		//인증 코드는 5분간 유효
+		redisUtil.setDataExpire(Integer.toString(authNumber), toMail, 60 * 5L);
 
-    }
+	}
 
 }

--- a/src/main/java/com/example/kbuddy_backend/common/config/EmailConfig.java
+++ b/src/main/java/com/example/kbuddy_backend/common/config/EmailConfig.java
@@ -4,30 +4,61 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Properties;
+
 @Configuration
 public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.transport.protocol}")
+    private String protocol;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.ssl.trust}")
+    private String sslTrust;
+
+    @Value("${spring.mail.properties.mail.smtp.ssl.protocols}")
+    private String sslProtocols;
+
+    @Value("${spring.mail.properties.mail.debug}")
+    private boolean debug;
+
     @Bean
-    public JavaMailSender mailSender() {//JAVA MAILSENDER 인터페이스를 구현한 객체를 빈으로 등록하기 위함.
-
+    public JavaMailSender mailSender() {
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-        mailSender.setHost("smtp.gmail.com");// 속성을 넣기 시작합니다. 이메일 전송에 사용할 SMTP 서버 호스트를 설정
-        mailSender.setPort(587);// 587로 포트를 지정
-        mailSender.setUsername("tripcompany77@gmail.com");
-        mailSender.setPassword("rexgraghaadpqpsn");//구글 앱 비밀번호
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
 
-        Properties javaMailProperties = new Properties();//JavaMail의 속성을 설정하기 위해 Properties 객체를 생성
-        javaMailProperties.put("mail.transport.protocol", "smtp");//프로토콜로 smtp 사용
-        javaMailProperties.put("mail.smtp.auth", "true");//smtp 서버에 인증이 필요
-        javaMailProperties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");//SSL 소켓 팩토리 클래스 사용
-        javaMailProperties.put("mail.smtp.starttls.enable", "true");//STARTTLS(TLS를 시작하는 명령)를 사용하여 암호화된 통신을 활성화
-        javaMailProperties.put("mail.debug", "true");//디버깅 정보 출력
-        javaMailProperties.put("mail.smtp.ssl.trust", "smtp.naver.com");//smtp 서버의 ssl 인증서를 신뢰
-        javaMailProperties.put("mail.smtp.ssl.protocols", "TLSv1.2");//사용할 ssl 프로토콜 버젼
+        Properties javaMailProperties = new Properties();
+        javaMailProperties.put("mail.transport.protocol", protocol);
+        javaMailProperties.put("mail.smtp.auth", auth);
+        javaMailProperties.put("mail.smtp.starttls.enable", starttlsEnable);
+        javaMailProperties.put("mail.smtp.ssl.trust", sslTrust);
+        javaMailProperties.put("mail.smtp.ssl.protocols", sslProtocols);
+        javaMailProperties.put("mail.debug", debug);
 
-        mailSender.setJavaMailProperties(javaMailProperties);//mailSender에 우리가 만든 properties 넣고
+        mailSender.setJavaMailProperties(javaMailProperties);
 
-        return mailSender;//빈으로 등록한다.
+        return mailSender;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,23 @@ spring:
     redis:
       host: redis
       port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        transport:
+          protocol: smtp
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          ssl:
+            trust: smtp.gmail.com
+            protocols: TLSv1.2
+        debug: true
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## Description (요약)
- 이메일 발송 주체 변경
- KBuddy 구글 계정 비밀번호가 코드에 그대로 노출되는 보안 이슈 해결

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [ ] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [X] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)
refer issue : https://github.com/KBuddy-devs/KBuddy-Server/issues/26

## Screenshots (optional)


## Etc (비고)
- 외부 계정 credential 등을 configuration에 녹일 때 application.yml을 활용하는 방안으로 로직을 통일할 것.
- **_깃허브 저장소에 업로드되는 모든 코드는 그 어떤 중요 credential도 노출이 되어서는 안됨!!!!!!!!! 진짜 중요_**